### PR TITLE
Fix for iOS 9 Banner not taking navigation bars into account properly

### DIFF
--- a/MessageBanner/Classes/MBLMessageBanner.m
+++ b/MessageBanner/Classes/MBLMessageBanner.m
@@ -392,13 +392,37 @@ static struct delegateMethodsCaching {
                 realViewController = viewController;
             }
             
-            [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:realViewController.topLayoutGuide
-                                                                            attribute:NSLayoutAttributeBottom
-                                                                            relatedBy:NSLayoutRelationEqual
-                                                                               toItem:message
-                                                                            attribute:NSLayoutAttributeTop
-                                                                           multiplier:1.0f
-                                                                             constant:0.0f]];
+            if (realViewController.navigationController && realViewController.navigationController.navigationBarHidden == YES) {
+                
+                [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:realViewController.view
+                                                                                attribute:NSLayoutAttributeTop
+                                                                                relatedBy:NSLayoutRelationEqual
+                                                                                   toItem:message
+                                                                                attribute:NSLayoutAttributeTop
+                                                                               multiplier:1.0f
+                                                                                 constant:0.0f]];
+            } else {
+                if (realViewController.navigationController.navigationBar != nil) {
+                    // This is a hack!!! iOS 9 the topLayoutGuide goes away and shows as nil in Reveal
+                    [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:realViewController.navigationController.navigationBar
+                                                                                    attribute:NSLayoutAttributeBottom
+                                                                                    relatedBy:NSLayoutRelationEqual
+                                                                                       toItem:message
+                                                                                    attribute:NSLayoutAttributeTop
+                                                                                   multiplier:1.0f
+                                                                                     constant:0.0f]];
+                } else {
+                    [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:realViewController.topLayoutGuide
+                                                                                    attribute:NSLayoutAttributeBottom
+                                                                                    relatedBy:NSLayoutRelationEqual
+                                                                                       toItem:message
+                                                                                    attribute:NSLayoutAttributeTop
+                                                                                   multiplier:1.0f
+                                                                                     constant:0.0f]];
+                }
+                
+                
+            }
             break;
         }
         case MBLMessageBannerPositionCenter: {


### PR DESCRIPTION
This fix is based in part @Loadex's  `feature/newTopLayout` branch.

This issue appears to be caused by a bug in iOS 9?

The statement `realtViewController.topLayoutGuide` seems to go away at some point after we set it here. To be clear it is not `nil` at run time when `[... constraintWithItem:realViewController.topLayoutGuide ...]` is called however when I bring this up in Reveal App the constraint is labeled as `???.bottom = MBLMessageBannerView:0x...` and the `First Item` is `Unknown`.

After a few hours banging my head against a wall this was the best I could come up with and it seems to work but I am skeptical as to how robust this really is.
